### PR TITLE
Implemented signrawtransaction with arguments

### DIFF
--- a/peercoin_rpc/peercoin_rpc.py
+++ b/peercoin_rpc/peercoin_rpc.py
@@ -238,6 +238,10 @@ class Client:
         '''signrawtransaction with privkey, returns status and rawtxhash'''
         return self.req("signrawtransaction", [rawtxhash])
 
+    def signrawtransactionWithArgs(self, rawtxhash, parent_tx_outputs, private_key):
+        '''signrawtransaction with privkey and arguments (parent tx outputs and private key) returns status and rawtxhash'''
+        return self.req("signrawtransaction", [rawtxhash,parent_tx_outputs,private_key])
+
     def sendrawtransaction(self, signed_rawtxhash):
         '''sends raw transaction, returns txid'''
         return self.req("sendrawtransaction", [signed_rawtxhash])


### PR DESCRIPTION
Today, I needed to sign a raw transaction with a private key that was not stored in the PeerCoin wallet. But, the implemented method assumed that the key was already stored in the wallet. Thus, I added this function to sign a raw transaction with all the arguments (except _sighash_) specified in the _signrawtransaction_ call.

`signrawtransaction <hex string> [{"txid":txid,"vout":n,"scriptPubKey":hex},...] [<privatekey1>,...] [sighash="ALL"]`